### PR TITLE
fixed-tsb-not-loading-for-pw

### DIFF
--- a/classes/local/injector.php
+++ b/classes/local/injector.php
@@ -64,7 +64,7 @@ class injector {
     public static function inject() {
         global $USER, $COURSE, $DB, $PAGE;
         $page_path =  $PAGE->url->get_path();
-        if (!preg_match('/mod\/quiz\/(attempt|summary|startattempt|view|report)/',$page_path )) {
+        if (!preg_match('/mod\/quiz\/(attempt|summary|startattempt|report)/',$page_path )) {
             return;
         }
         $enabled = get_config('local_proview', 'enabled');

--- a/version.php
+++ b/version.php
@@ -28,9 +28,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2023100201;
+$plugin->version  = 2023111301;
 $plugin->requires = 2020061500;
-$plugin->release = '3.2.0 (Build: 2023100201)';
+$plugin->release = '3.3.0 (Build: 2023111301)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 


### PR DESCRIPTION
## Description
- When a quiz is password protected and TSB is enabled, first TSB download page should be available and when the candidate joins the exam from TSB, Proview should launch.

## Github Issue
- Resolves #53 

## Checklist before requesting a review
- [ ] One line description of the changes is added in the PR
- [ ] Issue is linked to the PR via commits (eg: resolves #123)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires only a documentation update

