### PR TITLE
Fix boolean PHP warning in unit tests

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -354,9 +354,9 @@ class provider implements
      * @param array $reply An array containing Reply to addresses
      * @param array $from An array containing from addresses
      * @param string $txt The main body of the mail in plain text
-     * @return boolean true if mail is sent otherwise false
+     * @return bool true if mail is sent otherwise false
      */
-    private static function send_mail(array $to, array $reply, array $from, string $txt) : boolean {
+    private static function send_mail(array $to, array $reply, array $from, string $txt) : bool {
         $sitename = get_site();
         $token = get_config('local_proview', 'token');
         $account = get_config('local_proview', 'proview_acc_name');


### PR DESCRIPTION
## Description
Running unit tests in PHP 8.1 results in the following warning 
```
PHP Warning:  "boolean" will be interpreted as a class name. Did you mean "bool"? Write "\local_proview\privacy\boolean" or import the class with "use" to suppress this warning in /var/www/site/local/proview/classes/privacy/provider.php on line 359
```
A simple fix to change boolean to bool will remove the warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the return type in email sending functionality for consistency and improved logic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->