### PR TITLE
[94] [FIX] Close (X) icon is overriding the candidate id on playback view

### DIFF
--- a/templates/tracker.mustache
+++ b/templates/tracker.mustache
@@ -232,7 +232,7 @@
 
             var close = document.createElement('div');
             close.setAttribute("style","width: 100%;");
-            close.setAttribute("style","position: absolute; left: 15px; top: 4px; font-size: 28px;font-weight: bold;cursor: pointer;");
+            close.setAttribute("style","position: absolute; right: 40px; top: 4px; font-size: 28px;font-weight: bold;cursor: pointer;");
             close.innerHTML ='<span>&times;</span>';
             close.addEventListener("click", ()=>{
                 modal.setAttribute("style","display: none");

--- a/templates/tracker.mustache
+++ b/templates/tracker.mustache
@@ -202,7 +202,7 @@
                             .catch(function(error) {
                             console.error("Error:", error);
                             });
-                            modal.setAttribute("style","display: flex; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0, 0, 0, 0.4); justify-content: center; align-items: center;");
+                            modal.setAttribute("style","display: flex; position: fixed; z-index: 9999; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0, 0, 0, 0.4); justify-content: center; align-items: center;");
                 } }); }
                 node.appendChild(textnode);
                 parentNode = document.createElement("TD");
@@ -232,7 +232,7 @@
 
             var close = document.createElement('div');
             close.setAttribute("style","width: 100%;");
-            close.setAttribute("style","position: absolute; right: 35px;font-size: 28px;font-weight: bold;cursor: pointer;");
+            close.setAttribute("style","position: absolute; left: 15px; top: 4px; font-size: 28px;font-weight: bold;cursor: pointer;");
             close.innerHTML ='<span>&times;</span>';
             close.addEventListener("click", ()=>{
                 modal.setAttribute("style","display: none");

--- a/version.php
+++ b/version.php
@@ -28,9 +28,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2024060408;
+$plugin->version  = 2024070901;
 $plugin->requires = 2020061500;
-$plugin->release = '3.3.2 (Build: 2024060408)';
+$plugin->release = '3.3.3 (Build: 2024070901)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 

--- a/version.php
+++ b/version.php
@@ -28,9 +28,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2024070901;
+$plugin->version  = 2024081301;
 $plugin->requires = 2020061500;
-$plugin->release = '3.3.3 (Build: 2024070901)';
+$plugin->release = '3.3.4 (Build: 2024081301)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 


### PR DESCRIPTION
### **User description**
## Description
- fixed Close (X) icon is overriding the candidate id on session id on LMS applications 

## Github Issue
- resolves #94 

## Checklist before requesting a review
- [x] One line description of the changes is added in the PR
- [x] Issue is linked to the PR via commits (eg: resolves #123)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires only a documentation update


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the plugin version and release number in `version.php`.
- Adjusted the z-index of the modal in `templates/tracker.mustache` to ensure it appears above other elements.
- Modified the position of the close button in the modal to prevent it from overlapping with the candidate ID.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.php</strong><dd><code>Update plugin version and release number.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

version.php

- Updated plugin version and release number.



</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/95/files#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracker.mustache</strong><dd><code>Adjust modal z-index and close button position.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/tracker.mustache

<li>Adjusted modal z-index to 9999.<br> <li> Modified close button position to avoid overlapping with candidate ID.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/95/files#diff-00202831f79cb6ccdb62e6e1c4bb1ec31f05ea0bdeb30c38d90acd14ed372969">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

