### PR TITLE
Provision secure browser without proctoring

### DIFF
--- a/classes/local/api/tracker.php
+++ b/classes/local/api/tracker.php
@@ -87,10 +87,46 @@ class tracker
         ]);
         return $response;
     }
+    private static function redirect_to_wrapper($proctoring_payload, $quiz)
+    {
+        // TODO Add check if wrapper URL already exists
+        $wrapper_response = self::create_sb_wrapper($proctoring_payload, $quiz);
+        redirect($wrapper_response->signed_short_url);
+        return;
+    }
+
+    private static function create_sb_wrapper($proctoring_payload, $quiz)
+    {
+        global $PAGE;
+        $curl = new \curl();
+        $api_base_url = trim(get_config('quizaccess_proctor', 'proview_callback_url'));
+        $auth_payload = new \stdClass();
+        $auth_payload->username = trim(get_config('quizaccess_proctor', 'proview_admin_username'));
+        $auth_payload->password = trim(get_config('quizaccess_proctor', 'proview_admin_password'));
+        $auth_response = self::generate_auth_token($api_base_url, $auth_payload);
+        $auth_token = $auth_response['access_token'];
+        $url = $api_base_url . '/v1/wrapper/create';
+        $data = array(
+            'session_external_id' => $proctoring_payload->session_id,
+            'attendee_external_id' => $proctoring_payload->profile_id,
+            'redirect_url' => $PAGE->url->__toString(),
+            'expiry' => date(DATE_ISO8601, $quiz->timeclose == 0 ? strtotime("+3 days") : $quiz->timeclose ),
+            'is_secure_browser' => true
+        );
+        var_dump($data);
+        try {
+            $curl->setHeader(array('Content-Type: application/json', 'app-id: b37ec896-f62b-4cbe-b39f-8dd21881dfd3', 'Authorization: Bearer ' . $auth_token));
+            $response = $curl->post($url, json_encode($data));
+            $decoded_response = json_decode($response, false);
+            return $decoded_response;
+        } catch (\Throwable $err) {
+            self::capture_error($err);
+        }
+    }
 
 
 
-private static function generate_auth_token($api_base_url, $payload)
+    private static function generate_auth_token($api_base_url, $payload)
     {
         $curl = new \curl();
         $headers = array('Content-Type: application/json');
@@ -148,6 +184,21 @@ private static function generate_auth_token($api_base_url, $payload)
                 $attempt = $attempt->attempt;
             }
             $template->current_attempt = $attempt;
+            $quizaccess_proctor_setting = $DB->get_record('quizaccess_proctor', array('quizid' => $quiz->id));
+            if ($quizaccess_proctor_setting) {
+                $template->session_type = $quizaccess_proctor_setting->proctortype;
+            } else {
+                $template->session_type = "ai_proctor";
+            }
+            $template->session_id = $template->session_type === "live_proctor" ? $quiz->id.'-'.$USER->id : $quiz->id.'-'.$USER->id.'-'.$attempt;
+            if (strpos($PAGE->url, ('mod/quiz/attempt')) &&
+                $quizaccess_proctor_setting && 
+                $quizaccess_proctor_setting->proctortype == 'noproctor' && 
+                $quizaccess_proctor_setting->tsbenabled && 
+                strpos($_SERVER ['HTTP_USER_AGENT'], "Proview-SB") === FALSE) {
+                self::redirect_to_wrapper($template, $quiz);
+                return;
+            }
 
             if (strpos($PAGE->url, ('mod/quiz/report'))) {
                 $quiz_attempts = $DB->get_records('quiz_attempts', array('quiz' => $quiz->id));
@@ -160,6 +211,7 @@ private static function generate_auth_token($api_base_url, $payload)
                 $template->attempts = json_encode($quiz_attempts);
             }
         }
+
         if ($pageinfo && !empty($template->token)) {
             // The templates only contains a "{js}" block; so we don't care about
             // the output; only that the $PAGE->requires are filled.

--- a/classes/local/api/tracker.php
+++ b/classes/local/api/tracker.php
@@ -105,7 +105,7 @@ class tracker
         $auth_payload->password = trim(get_config('quizaccess_proctor', 'proview_admin_password'));
         $auth_response = self::generate_auth_token($api_base_url, $auth_payload);
         $auth_token = $auth_response['access_token'];
-        $url = $api_base_url . '/v1/wrapper/create';
+        $url = $api_base_url . '/proview/wrapper/create';
         $data = array(
             'session_external_id' => $proctoring_payload->session_id,
             'attendee_external_id' => $proctoring_payload->profile_id,

--- a/classes/local/injector.php
+++ b/classes/local/injector.php
@@ -79,6 +79,11 @@ class injector {
                 $quizaccess_proctor_setting = $DB->get_record('quizaccess_proctor', array('quizid' => $quiz->id));
                 if ((!$quizaccess_proctor_setting) ||
                     ($quizaccess_proctor_setting && $quizaccess_proctor_setting->proctortype == 'noproctor')) {
+                        if (($quizaccess_proctor_setting->tsbenabled && strpos($_SERVER ['HTTP_USER_AGENT'], "Proview-SB") === FALSE)) {
+                            $t = new api\tracker();
+                            $t::insert_tracking();
+                            return;
+                        }
                     self::inject_password($PAGE, $quiz);
                     return;
                 }

--- a/version.php
+++ b/version.php
@@ -28,9 +28,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2024082601;
+$plugin->version  = 2024082604;
 $plugin->requires = 2020061500;
-$plugin->release = '3.3.5 (Build: 2024082601)';
+$plugin->release = '3.3.5 (Build: 2024082604)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 

--- a/version.php
+++ b/version.php
@@ -28,9 +28,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2024081301;
+$plugin->version  = 2024082601;
 $plugin->requires = 2020061500;
-$plugin->release = '3.3.4 (Build: 2024081301)';
+$plugin->release = '3.3.5 (Build: 2024082601)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 


### PR DESCRIPTION
### **User description**
- **[94] [FIX] Close (X) icon is overriding the candidate id on playback view (#95)**
- **Generate and provide a wrapper link if only SB is enabled for a quiz**

## Description
- Please include a summary of the change.

## Github Issue
- Add github issue link and title (eg: resolves #123)

## Checklist before requesting a review
- [x] One line description of the changes is added in the PR
- [x] Issue is linked to the PR via commits (eg: resolves #123)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires only a documentation update

## Dependencies (if any):
- https://github.com/talview/lms-connector-api/issues/196

## References (if any):
- [ ] Any reference documents to review before/after this PR review
- Add the links of any related PR/documents/diagrams for reviewers reference (eg: #link to understand login flow).


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Implemented a secure browser wrapper for quizzes without proctoring, including functions to create and redirect to the wrapper.
- Added logic to handle sessions without proctoring, including session ID generation and tracking injection.
- Updated the plugin version and release information to reflect new changes.
- Fixed the position of the close button in the modal to prevent it from overriding other elements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracker.php</strong><dd><code>Implement secure browser wrapper and session handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

classes/local/api/tracker.php

<li>Added functions to create and redirect to a secure browser wrapper.<br> <li> Implemented logic to handle sessions without proctoring.<br> <li> Adjusted session ID generation based on proctor type.<br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/100/files#diff-66c9a7e686d6a2adde5be2d0e4bc1cdf6dcfafd1322381c1619020739f72271a">+53/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>injector.php</strong><dd><code>Add tracking injection for non-proctored sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

classes/local/injector.php

<li>Added condition to inject tracking for sessions without proctoring.<br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/100/files#diff-d5faaa72a86d7145145229e0b6327aeced791eba944f8c6e7970e5eeb8b47474">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.php</strong><dd><code>Update plugin version and release details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

version.php

- Updated plugin version and release information.



</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/100/files#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracker.mustache</strong><dd><code>Fix modal close button position</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/tracker.mustache

- Adjusted position of the close button in the modal.



</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/100/files#diff-00202831f79cb6ccdb62e6e1c4bb1ec31f05ea0bdeb30c38d90acd14ed372969">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

