### PR TITLE
Add additional parameters for enabling secure Browser

### DIFF
--- a/classes/local/api/tracker.php
+++ b/classes/local/api/tracker.php
@@ -119,7 +119,7 @@ class tracker
         );
         var_dump($data);
         try {
-            $curl->setHeader(array('Content-Type: application/json', 'app-id: b37ec896-f62b-4cbe-b39f-8dd21881dfd3', 'Authorization: Bearer ' . $auth_token));
+            $curl->setHeader(array('Content-Type: application/json', 'Authorization: Bearer ' . $auth_token));
             $response = $curl->post($url, json_encode($data));
             $decoded_response = json_decode($response, false);
             return $decoded_response;

--- a/classes/local/api/tracker.php
+++ b/classes/local/api/tracker.php
@@ -90,12 +90,12 @@ class tracker
     private static function redirect_to_wrapper($proctoring_payload, $quiz)
     {
         // TODO Add check if wrapper URL already exists
-        $wrapper_response = self::create_sb_wrapper($proctoring_payload, $quiz);
+        $wrapper_response = self::create_sb_wrapper($proctoring_payload, $quiz, $quizaccess_proctor_setting);
         redirect($wrapper_response->signed_short_url);
         return;
     }
 
-    private static function create_sb_wrapper($proctoring_payload, $quiz)
+    private static function create_sb_wrapper($proctoring_payload, $quiz, $quizaccess_proctor_setting)
     {
         global $PAGE;
         $curl = new \curl();
@@ -111,7 +111,11 @@ class tracker
             'attendee_external_id' => $proctoring_payload->profile_id,
             'redirect_url' => $PAGE->url->__toString(),
             'expiry' => date(DATE_ISO8601, $quiz->timeclose == 0 ? strtotime("+3 days") : $quiz->timeclose ),
-            'is_secure_browser' => true
+            'is_secure_browser' => true,
+            'blacklisted_softwares_windows' => $quizaccess_proctor_setting->sb_blacklisted_software_windows,
+            'blacklisted_softwares_mac' => $quizaccess_proctor_setting->sb_blacklisted_software_mac,
+            'is_minimize' => $quizaccess_proctor_setting->sb_kiosk_mode_enable,
+            'is_record_screen' => $quizaccess_proctor_setting->sb_content_protection_enable
         );
         var_dump($data);
         try {
@@ -196,7 +200,7 @@ class tracker
                 $quizaccess_proctor_setting->proctortype == 'noproctor' && 
                 $quizaccess_proctor_setting->tsbenabled && 
                 strpos($_SERVER ['HTTP_USER_AGENT'], "Proview-SB") === FALSE) {
-                self::redirect_to_wrapper($template, $quiz);
+                self::redirect_to_wrapper($template, $quiz, $quizaccess_proctor_setting);
                 return;
             }
 

--- a/classes/local/api/tracker.php
+++ b/classes/local/api/tracker.php
@@ -112,10 +112,10 @@ class tracker
             'redirect_url' => $PAGE->url->__toString(),
             'expiry' => date(DATE_ISO8601, $quiz->timeclose == 0 ? strtotime("+3 days") : $quiz->timeclose ),
             'is_secure_browser' => true,
-            'blacklisted_softwares_windows' => $quizaccess_proctor_setting->sb_blacklisted_software_windows,
-            'blacklisted_softwares_mac' => $quizaccess_proctor_setting->sb_blacklisted_software_mac,
-            'is_minimize' => $quizaccess_proctor_setting->sb_kiosk_mode_enable,
-            'is_record_screen' => $quizaccess_proctor_setting->sb_content_protection_enable
+            'blacklisted_softwares_windows' => $quizaccess_proctor_setting->blacklisted_softwares_win,
+            'blacklisted_softwares_mac' => $quizaccess_proctor_setting->blacklisted_softwares_mac,
+            'is_minimize' => $quizaccess_proctor_setting->sb_kiosk_mode,
+            'is_record_screen' => $quizaccess_proctor_setting->sb_content_protection
         );
         var_dump($data);
         try {

--- a/datastore.php
+++ b/datastore.php
@@ -89,6 +89,13 @@ if ($sesskey == sesskey()) {
     $template->profile_id = $USER->id;
     $template->instructions = $quizaccess_proctor_setting->instructions;
     $template->reference_link= $quizaccess_proctor_setting->reference_link;
+    $template->tsbenabled= $quizaccess_proctor_setting->tsbenabled;
+    if ($template->tsbenabled && $template->tsbenabled === 1 ) {
+        $template->sb_blacklisted_software_windows= $quizaccess_proctor_setting->sb_blacklisted_software_windows;
+        $template->sb_blacklisted_software_mac= $quizaccess_proctor_setting->sb_blacklisted_software_mac;
+        $template->minimize_permitted= $quizaccess_proctor_setting->sb_kiosk_mode_enable;
+        $template->screen_protection= $quizaccess_proctor_setting->sb_content_protection_enable;
+    }
     $template->session_id = $template->session_type === "live_proctor" ? $quizid.'-'.$USER->id : $quizid.'-'.$USER->id.'-'.$attempt;   // Do not append attempt number for live proctoring. Re-attempting same quiz not supported in live proctoring.
     $template->proview_url = trim(get_config('local_proview', 'proview_url'));
     $template->token = trim(get_config('local_proview', 'token'));

--- a/datastore.php
+++ b/datastore.php
@@ -90,11 +90,11 @@ if ($sesskey == sesskey()) {
     $template->instructions = $quizaccess_proctor_setting->instructions;
     $template->reference_link= $quizaccess_proctor_setting->reference_link;
     $template->tsbenabled= $quizaccess_proctor_setting->tsbenabled;
-    if ($template->tsbenabled && $template->tsbenabled === 1 ) {
-        $template->sb_blacklisted_software_windows= $quizaccess_proctor_setting->sb_blacklisted_software_windows;
-        $template->sb_blacklisted_software_mac= $quizaccess_proctor_setting->sb_blacklisted_software_mac;
-        $template->minimize_permitted= $quizaccess_proctor_setting->sb_kiosk_mode_enable;
-        $template->screen_protection= $quizaccess_proctor_setting->sb_content_protection_enable;
+    if ($template->tsbenabled && $template->tsbenabled === "1" ) {
+        $template->sb_blacklisted_software_windows= $quizaccess_proctor_setting->blacklisted_softwares_win;
+        $template->sb_blacklisted_software_mac= $quizaccess_proctor_setting->blacklisted_softwares_mac;
+        $template->minimize_permitted= $quizaccess_proctor_setting->sb_kiosk_mode;
+        $template->screen_protection= $quizaccess_proctor_setting->sb_content_protection;
     }
     $template->session_id = $template->session_type === "live_proctor" ? $quizid.'-'.$USER->id : $quizid.'-'.$USER->id.'-'.$attempt;   // Do not append attempt number for live proctoring. Re-attempting same quiz not supported in live proctoring.
     $template->proview_url = trim(get_config('local_proview', 'proview_url'));

--- a/frame.php
+++ b/frame.php
@@ -126,11 +126,11 @@ echo $OUTPUT->header();
             clear: clear || false,
             skipHardwareTest: skipHardwareTest || false,
             previewStyle: previewStyle || 'position: fixed; bottom: 0px;',
-            enforceTSB: tsbenabled === 1 ? true : false,
+            enforceTSB: enforceTSB === "1" ? true : false,
             blacklistedSoftwaresWindows: blacklistedSoftwaresWindows || "",
             blacklistedSoftwaresMac: blacklistedSoftwaresMac || "",
-            minimizeOption: minimizeOption === "true" ? true : false,
-            isScreenProtectionEnabled: isScreenProtectionEnabled || true,
+            minimizeOption: minimizeOption === "1" ? true : false,
+            isScreenProtectionEnabled: isScreenProtectionEnabled === "1" ? true : false,
             initCallback: createCallback(proview_playback_url, profileId, session_type)/* onProviewStart */
       });
     }
@@ -231,6 +231,7 @@ echo $OUTPUT->header();
               response=xmlhttp.responseText;
               response=JSON.parse(response);
               window.quizPassword = response.quiz_password;
+              console.log(response);
               startProview(
                 {
                   authToken: response.token, 

--- a/frame.php
+++ b/frame.php
@@ -231,7 +231,6 @@ echo $OUTPUT->header();
               response=xmlhttp.responseText;
               response=JSON.parse(response);
               window.quizPassword = response.quiz_password;
-              console.log(response);
               startProview(
                 {
                   authToken: response.token, 

--- a/frame.php
+++ b/frame.php
@@ -83,7 +83,7 @@ echo $OUTPUT->header();
     //Javascript function to start proview invoked upon postMessage from iframe
 
 
-    function startProview(
+    function startProview({
         authToken, 
         profileId, 
         session, 
@@ -92,9 +92,15 @@ echo $OUTPUT->header();
         additionalInstruction,
         reference_link,
         proview_playback_url,
+        enforceTSB,
+        blacklistedSoftwaresWindows,
+        blacklistedSoftwaresMac,
+        isScreenProtectionEnabled,
+        minimizeOption,
         skipHardwareTest,
         previewStyle, 
-        clear) {
+        clear
+      }) {
         const referenceLinksArray = reference_link.match(/\[([^\]]+)\]\(([^)]+)\)/g)?.map(markdownLink => {
             const match = markdownLink.match(/\[([^\]]+)\]\(([^)]+)\)/);
             if (match) {
@@ -120,6 +126,11 @@ echo $OUTPUT->header();
             clear: clear || false,
             skipHardwareTest: skipHardwareTest || false,
             previewStyle: previewStyle || 'position: fixed; bottom: 0px;',
+            enforceTSB: tsbenabled === 1 ? true : false,
+            blacklistedSoftwaresWindows: blacklistedSoftwaresWindows || "",
+            blacklistedSoftwaresMac: blacklistedSoftwaresMac || "",
+            minimizeOption: minimizeOption === "true" ? true : false,
+            isScreenProtectionEnabled: isScreenProtectionEnabled || true,
             initCallback: createCallback(proview_playback_url, profileId, session_type)/* onProviewStart */
       });
     }
@@ -220,7 +231,23 @@ echo $OUTPUT->header();
               response=xmlhttp.responseText;
               response=JSON.parse(response);
               window.quizPassword = response.quiz_password;
-              startProview(response.token, response.profile_id, response.session_id, response.session_type, response.proview_url, response.instructions, response.reference_link, response.proview_playback_url);
+              startProview(
+                {
+                  authToken: response.token, 
+                  profileId: response.profile_id, 
+                  session: response.session_id, 
+                  session_type: response.session_type, 
+                  proview_url: response.proview_url, 
+                  additionalInstruction: response.instructions, 
+                  reference_link: response.reference_link, 
+                  proview_playback_url: response.proview_playback_url,
+                  enforceTSB: response.tsbenabled,
+                  blacklistedSoftwaresWindows: response.sb_blacklisted_software_windows,
+                  blacklistedSoftwaresMac: response.sb_blacklisted_software_mac,
+                  isScreenProtectionEnabled: response.minimize_permitted,
+                  minimizeOption: response.screen_protection
+                }
+              );
             }
           }
           xmlhttp.open("GET", "datastore.php?quiz_id=" + urlParams.get('quizId') + "&sesskey=" + "<?php echo $sesskey?>" , true);

--- a/version.php
+++ b/version.php
@@ -28,12 +28,12 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2024091901;
+$plugin->version  = 2024092606;
 $plugin->requires = 2020061500;
-$plugin->release = '3.4.0 (Build: 2024091901)';
+$plugin->release = '3.4.0 (Build: 2024092606)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 
 $plugin->dependencies = array(
-    'quizaccess_proctor' => 2024091701,
+    'quizaccess_proctor' => 2024092606,
 );

--- a/version.php
+++ b/version.php
@@ -28,12 +28,12 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2024082604;
+$plugin->version  = 2024091901;
 $plugin->requires = 2020061500;
-$plugin->release = '3.3.5 (Build: 2024082604)';
+$plugin->release = '3.4.0 (Build: 2024091901)';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'local_proview';
 
 $plugin->dependencies = array(
-    'quizaccess_proctor' => 2024022802,
+    'quizaccess_proctor' => 2024091701,
 );


### PR DESCRIPTION
### **User description**
## Description
- Add additional parameters for enabling secure Browser

## Github Issue
- #101 
## Checklist before requesting a review
- [x] One line description of the changes is added in the PR
- [x] Issue is linked to the PR via commits (eg: resolves #123)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires only a documentation update

## Dependencies (if any):
- https://github.com/talview/moodle-quizaccess_proctor/pull/52


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the secure browser configuration by adding additional parameters such as blacklisted software and screen protection settings.
- Updated the `create_sb_wrapper` and `redirect_to_wrapper` functions to include new secure browser settings.
- Modified the JavaScript `startProview` function to handle additional secure browser parameters.
- Updated the plugin version and dependencies to reflect the new changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracker.php</strong><dd><code>Enhance secure browser configuration in API tracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

classes/local/api/tracker.php

<li>Added <code>quizaccess_proctor_setting</code> parameter to <code>create_sb_wrapper</code> and <br><code>redirect_to_wrapper</code> functions.<br> <li> Included additional secure browser settings in the <code>create_sb_wrapper</code> <br>function.<br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/102/files#diff-66c9a7e686d6a2adde5be2d0e4bc1cdf6dcfafd1322381c1619020739f72271a">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>datastore.php</strong><dd><code>Add secure browser settings to datastore template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

datastore.php

<li>Added new secure browser settings to the template.<br> <li> Conditional logic for setting secure browser parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/102/files#diff-6117df4aaadd93020fe8545f614c967dd1b298a093d8150d747fc35d31105bbf">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>frame.php</strong><dd><code>Update JavaScript to handle secure browser parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frame.php

<li>Updated <code>startProview</code> function to accept additional secure browser <br>parameters.<br> <li> Modified <code>run</code> function to pass new parameters to <code>startProview</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/102/files#diff-9221f976935de91cfad64ab3ec4bc1c854fa68709e21c4cb338c04b20eb599bf">+30/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.php</strong><dd><code>Update plugin version and dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

version.php

<li>Updated plugin version and release information.<br> <li> Adjusted plugin dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/talview/moodle-local_proview/pull/102/files#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

